### PR TITLE
feat: add custom inputs metric with backwards compatibility

### DIFF
--- a/backend/controllers/benchmarkResultController.js
+++ b/backend/controllers/benchmarkResultController.js
@@ -43,11 +43,21 @@ export const receiveBenchmarkResult = async (req, res) => {
       }
     }
 
-    // Add the benchmark data to Firestore
-    const docRef = await db.collection(COLLECTION_NAMES.BENCHMARKS).add({
+    // Prepare data for Firestore, including custom inputs if they exist
+    const firestoreData = {
       ...data,
-      createdAt: new Date().toISOString()
-    });
+      createdAt: new Date().toISOString(),
+    };
+
+    // If customInputs exists, process and add it
+    if (data.customInputs) {
+      // Assuming customInputs is an object like { "Proving time": "1024" }
+      // We can add it directly to the document
+      firestoreData.customInputs = data.customInputs;
+    }
+
+    // Add the benchmark data to Firestore
+    const docRef = await db.collection(COLLECTION_NAMES.BENCHMARKS).add(firestoreData);
 
     logger.info(`Benchmark data saved successfully with ID: ${docRef.id}`);
 

--- a/benchmarking-suite/moPro/mopro-example-app/flutter/lib/main.dart
+++ b/benchmarking-suite/moPro/mopro-example-app/flutter/lib/main.dart
@@ -2556,6 +2556,11 @@ Timestamp: ${DateTime.now().millisecondsSinceEpoch}
   }
   
   Map<String, dynamic> _prepareBenchmarkData(Map<String, dynamic> deviceInfo) {
+    // Prepare custom inputs
+    final Map<String, String> customInputs = {
+      widget.selectedInputName: '[${widget.selectedInputData.values.join(', ')}]'
+    };
+
     return {
       // Circuit and framework info
       'circuit': widget.algorithm,
@@ -2571,6 +2576,7 @@ Timestamp: ${DateTime.now().millisecondsSinceEpoch}
       
       // Additional metadata
       'proofSize': _getProofSize(),
+      'customInputs': customInputs, // Add custom inputs here
 
       'timestamp': DateTime.now().toIso8601String(),
     };

--- a/website/src/app/benchmarks/page.tsx
+++ b/website/src/app/benchmarks/page.tsx
@@ -404,6 +404,26 @@ export default function BenchmarksPage() {
                                     )}
                                   </div>
                                 </div>
+                                
+                                {/* Custom Inputs */}
+                                {item.customInputs && Object.keys(item.customInputs).length > 0 && (
+                                  <div className="bg-white rounded-lg p-3 shadow-sm border border-[rgba(55,50,47,0.12)]">
+                                    <h4 className="text-xs font-bold text-[#37322F] mb-2 flex items-center">
+                                      <svg className="w-4 h-4 mr-1.5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+                                      </svg>
+                                      Custom Inputs
+                                    </h4>
+                                    <div className="space-y-1.5 text-xs">
+                                      {Object.entries(item.customInputs).map(([key, value]) => (
+                                        <div key={key} className="flex justify-between">
+                                          <span className="text-[#605A57]">{key}:</span>
+                                          <span className="font-medium text-[#37322F]">{value}</span>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  </div>
+                                )}
 
                                 {/* Timestamp */}
                                 <div className="bg-white rounded-lg p-3 shadow-sm md:col-span-2 lg:col-span-3">

--- a/website/src/app/types.ts
+++ b/website/src/app/types.ts
@@ -41,4 +41,5 @@ export interface BenchmarkData {
   proofSize: number;
   timestamp: string;
   createdAt?: string;
+  customInputs?: { [key: string]: string };
 }


### PR DESCRIPTION
This PR adds support for custom inputs as a metric for which the whole benchmark was done for. This is backwards compatible with the previous data we have collected till now.